### PR TITLE
Move project image preloading from ProjectsModal to ClientLayout usin…

### DIFF
--- a/app/components/ClientLayout.tsx
+++ b/app/components/ClientLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import Loader from "./Loader";
 import { useResourceLoader } from "../hooks/useResourceLoader";
 import { projects } from "../data/projects";
@@ -48,5 +49,24 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
   }
 
   // Show main content once loading is complete
-  return <>{children}</>;
+  return (
+    <>
+      {/* Hidden preload container for project images using Next.js Image optimization */}
+      <div className="hidden" aria-hidden="true">
+        {projects.flatMap((project) =>
+          project.images.map((src, idx) => (
+            <Image
+              key={`preload-${src}-${idx}`}
+              src={src}
+              alt=""
+              width={1200}
+              height={800}
+              priority
+            />
+          ))
+        )}
+      </div>
+      {children}
+    </>
+  );
 }

--- a/app/components/ProjectsModal.tsx
+++ b/app/components/ProjectsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import React, { useEffect, useCallback, useRef } from "react";
 import Image from "next/image";
 import { NavigationButton } from "./modal/NavigationButton";
 import { ModalHeader } from "./modal/ModalHeader";
@@ -33,7 +33,6 @@ export const ProjectsModal: React.FC<ProjectsModalProps> = ({
   onImageSelect,
   onImageNavigate,
 }) => {
-  const [preloadedImages, setPreloadedImages] = useState<Set<string>>(new Set());
   const touchStartX = useRef<number | null>(null);
   const touchEndX = useRef<number | null>(null);
 
@@ -128,22 +127,6 @@ export const ProjectsModal: React.FC<ProjectsModalProps> = ({
         }`}
         onClick={onClose}
       />
-
-      {/* Hidden preload container for all images */}
-      <div className="hidden">
-        {projects.flatMap((project) =>
-          project.images.map((src, idx) => (
-            <Image
-              key={`preload-${src}-${idx}`}
-              src={src}
-              alt=""
-              width={1}
-              height={1}
-              priority
-            />
-          ))
-        )}
-      </div>
 
       {/* MOBILE LAYOUT */}
       <div


### PR DESCRIPTION
…g Next.js Image optimization

- Move project images preloading from ProjectsModal to ClientLayout for earlier loading
- Use Next.js Image component with proper dimensions (1200x800) instead of 1x1 placeholder
- Add hidden preload container with aria-hidden in ClientLayout
- Remove redundant preloading logic and unused preloadedImages state from ProjectsModal
- Ensure project images load with other critical resources on initial page load