### PR TITLE
Change external link navigation from window.open to window.location.h…

### DIFF
--- a/components/Dock.jsx
+++ b/components/Dock.jsx
@@ -53,7 +53,9 @@ function DockItem({
   const handleClick = () => {
     if (href) {
       if (external) {
-        window.open(href, "_blank");
+        // Use window.location.href for better mobile compatibility
+        // This opens in the same tab but maintains proper navigation history
+        window.location.href = href;
       } else {
         // Use Next.js router for internal navigation
         router.push(href);


### PR DESCRIPTION
…ref for better mobile compatibility

- Replace window.open(href, "_blank") with window.location.href in DockItem
- Opens external links in same tab instead of new tab to maintain proper navigation history on mobile devices
- Add explanatory comments for the change